### PR TITLE
Issues when sending via Amazon SES

### DIFF
--- a/dada/DADA/Mail/Send.pm
+++ b/dada/DADA/Mail/Send.pm
@@ -877,7 +877,11 @@ sub send {
 					-msg => $msg, 
 				}
 			);
-			if($response_code != 200){
+			if($response_code == 200){ 				
+				my($sesMessageId, $sesRequestId) = split("\n", $response_content);
+				#do something here about the message id
+			}
+			else { 
 				return -1; 
 			}
 		}

--- a/dada/DADA/perllib/Net/Amazon/SES.pm
+++ b/dada/DADA/perllib/Net/Amazon/SES.pm
@@ -362,8 +362,19 @@ sub send_msg {
         'Action'          => 'SendRawEmail'
     };
 
-    return $self->call_ses( $params, {} );
+	my ($response_code, $response_content) = $self->call_ses($params, {});
+		if ( $self->trace ) {
+			print $response_code . "\n"; 
+			print $response_content . "\n"; 
+		}	
 
+
+	if($response_code eq '200') { 
+		return ($response_code, $self->get_send_response($response_content));
+	}
+	else { 
+		return ($response_code, $response_content);
+	}
 }
 
 # Read the credentials from $AWS_CREDENTIALS_FILE file.
@@ -615,7 +626,6 @@ sub call_ses {
     my $response = $browser->request($request);
 
     if ( $self->trace ) {
-
         #	carp $response->content;
     }
 
@@ -634,7 +644,29 @@ sub call_ses {
 
     #my $t1 = gettimeofday();
     #carp "mailing time: " . ($t1 - $t0);
-    return ( $response->code, $response->content );
+	
+	return ($response->code, $response->content);
+}
+
+# Gets response sent by amazon
+sub get_send_response {
+	my $self = shift;
+    my $response_content = shift;
+
+    my $parser = XML::LibXML->new();
+    my $dom = $parser->parse_string($response_content);
+    my $xpath = XML::LibXML::XPathContext->new($dom);
+    $xpath->registerNs('ns', $aws_email_ns);
+	
+    my $messageId = $xpath->find('/ns:SendRawEmailResponse' .
+	                             '/ns:SendRawEmailResult' .
+								 '/ns:MessageId');
+
+    my $requestId = $xpath->find('/ns:SendRawEmailResponse' .
+	                             '/ns:ResponseMetadata' .
+	                             '/ns:RequestId');
+
+	return $messageId . "\n" . $requestId;
 }
 
 # Prints tha data returned by the service call.


### PR DESCRIPTION
As per AWS Documentation, Amazon SES accepts any email headers that
follows RFC 822, so the cleaning function isn't necessary anymore.

They do however, replace Message-Id, so I left it as X-Message-Id.

http://docs.aws.amazon.com/ses/latest/DeveloperGuide/header-fields.html
