### PR TITLE
Add option to set "digest" as the default delivery preference

### DIFF
--- a/dada/DADA/Config.pm
+++ b/dada/DADA/Config.pm
@@ -1565,6 +1565,7 @@ $MIME_TOOLS_PARAMS //= {
     digest_enable               => 0, 
     digest_schedule             => 86400, 
     digest_last_archive_id_sent => undef, 
+    digest_bydefault            => 0,
 
     # Tracker
     tracker_record_view_count                       => 10,

--- a/dada/DADA/MailingList/Subscriber/baseSQL.pm
+++ b/dada/DADA/MailingList/Subscriber/baseSQL.pm
@@ -227,6 +227,24 @@ sub add {
         }
         ##########################################################################
 
+        ##################
+        # Bridge Delivery Default #
+        ##########################################################################
+        require DADA::MailingList::Settings;
+        my $ls = DADA::MailingList::Settings->new( { -list => $args->{-list} } );
+        if ( $ls->param( 'digest_enable' ) == 1 && $ls->param( 'digest_bydefault' ) == 1 ) {
+            use DADA::Profile::Settings;
+            my $dps = DADA::Profile::Settings->new;
+            my $r   = $dps->save(
+                { 
+                   -email   => $args->{-email},
+                   -list    => $args->{-list},
+                   -setting => 'delivery_prefs',
+                   -value   => 'digest',
+                }
+            );
+        }
+        ##########################################################################
     }
 
     my $added_args = {

--- a/dada/plugins/bridge
+++ b/dada/plugins/bridge
@@ -668,6 +668,7 @@ sub edit {
         discussion_template_defang                 => 0,
         digest_enable   => 0,
         digest_schedule => 86400,
+        digest_bydefault => 0,
         bridge_announce_reply_to => 'none', 
         
     );

--- a/dada/templates/plugins/bridge/default.tmpl
+++ b/dada/templates/plugins/bridge/default.tmpl
@@ -1016,7 +1016,20 @@
 				<!-- tmpl_var digest_schedule_popup_menu -->
 			</div> 
 		</div> 
-		
+		<div class="row">
+			<div class="small-12 columns">				
+				<label for="digest_bydefault"> 
+					<input 
+						type="checkbox" 
+						name="digest_bydefault" 
+						id="digest_bydefault" 
+						value="1" 
+						<!-- tmpl_if list_settings.digest_bydefault --> checked="checked"<!-- /tmpl_if -->
+					>
+					Set Delivery Preferences to Digest By Default
+				</label> 
+			</div> 
+		</div> 
 	</fieldset> 
 
 


### PR DESCRIPTION
This feature adds a checkbox to the Bridge configuration page, in the Digests section, labeled "Set Delivery Preferences to Digest By Default". When enabled, the delivery preference will be set to digest instead of individual for new subscribers.