### PR TITLE
Fix: regex for table names to create

### DIFF
--- a/dada/DADA/App/Guts.pm
+++ b/dada/DADA/App/Guts.pm
@@ -2213,12 +2213,12 @@ sub create_probable_missing_tables {
         my $table_name = undef;
         if ( $db_type eq 'Pg' ) {
             $table_name = $create_table;
-            $table_name =~ m/CREATE TABLE (.*?) \(/;
+            $table_name =~ m/CREATE TABLE (\S+) +\(/;
             $table_name = $1;
         }
         else {
             $table_name = $create_table;
-            $table_name =~ m/CREATE TABLE IF NOT EXISTS (.*?) \(/;
+            $table_name =~ m/CREATE TABLE IF NOT EXISTS (\S+) +\(/;
             $table_name = $1;
 			$table_name = strip($table_name);
         }


### PR DESCRIPTION
On performing a big upgrade through many versions we discovered that the new tables in extras/SQL/postgres_schema.sql were not being created properly because the regex in Guts.pm didn't account for more than one space between the tablename and the following open bracket.

This is a simple PR which fixes this by making each regex more lenient.